### PR TITLE
Fixes nil access in template when monit attributes are not defined

### DIFF
--- a/templates/default/monit-rc.erb
+++ b/templates/default/monit-rc.erb
@@ -14,12 +14,12 @@ set alert <%= email %>
     <% end %>
   <% end %>
   <% if node[:monit][:mailserver] %>
-    set mailserver <%= node[:monit][:mailserver][:host] %> port <%= node[:monit][:mailserver][:port] %>
-    username "<%= node[:monit][:mailserver][:username] %>"
-    password "<%= node[:monit][:mailserver][:password] %>"
-    using tlsv1
-    with timeout 30 seconds
-    using hostname "<%= node[:monit][:mailserver][:hostname] %>"
+set mailserver <%= node[:monit][:mailserver][:host] %> port <%= node[:monit][:mailserver][:port] %>
+  username "<%= node[:monit][:mailserver][:username] %>"
+  password "<%= node[:monit][:mailserver][:password] %>"
+  using tlsv1
+  with timeout 30 seconds
+  using hostname "<%= node[:monit][:mailserver][:hostname] %>"
   <% end %>
 <% end %>
 


### PR DESCRIPTION
If monit attributes are not defined, a nil access error will occur.
