### PR TITLE
fix unmatched quote, and allow for from address, etc. config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,5 @@
 default[:monit][:notify_emails] = false
+default[:monit][:mailserver][:emailfrom] = "emailfrom@example.com"
+default[:monit][:mailserver][:emailreplyto] = "emailreplyto@example.com"
+default[:monit][:mailserver][:emailsubject] = "$SERVICE $EVENT at $DATE"
+default[:monit][:mailserver][:emailmessage] = "Monit $ACTION $SERVICE at $DATE on $HOST: $DESCRIPTION.\nYours sincerely,\nmonit"

--- a/templates/default/monit-rc.erb
+++ b/templates/default/monit-rc.erb
@@ -15,13 +15,19 @@ set alert <%= email %>
   <% end %>
 
 <% if node[:monit][:mailserver] %>
-set mailserver "<%= node[:monit][:mailserver][:host] %>' port <%= node[:monit][:mailserver][:port] %>"
+set mailserver "<%= node[:monit][:mailserver][:host] %>" port <%= node[:monit][:mailserver][:port] %>
   username "<%= node[:monit][:mailserver][:username] %>"
   password "<%= node[:monit][:mailserver][:password] %>"
   using tlsv1
   with timeout 30 seconds
   using hostname "<%= node[:monit][:mailserver][:hostname] %>"
 <% end %>
+set mail-format {
+  <% if node[:monit][:mailserver][:emailfrom] %> from:     <%= node[:monit][:mailserver][:emailfrom] %> <% end %>
+  <% if node[:monit][:mailserver][:emailreplyto] %> reply-to: <%= node[:monit][:mailserver][:emailreplyto] %> <% end %>
+  <% if node[:monit][:mailserver][:emailsubject] %> subject:  "<%= node[:monit][:mailserver][:emailsubject] %>" <% end %>
+  <% if node[:monit][:mailserver][:emailmessage] %> message:  "<%= node[:monit][:mailserver][:emailmessage] %>" <% end %>
+ }
 <% end %>
 
 set httpd port 2812 and


### PR DESCRIPTION
There was a mismatched single quote as a result of the recent (June) patch, which prevented monit from connecting to my smtp server.  monit also complains if the port is quoted.

Also, my smtp server wanted the "from" email address to be set.  Thus, this commit addresses those two issues.

Thanks!